### PR TITLE
ci: allow gh-pages push with GitHub token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant write permissions to workflow so GITHUB_TOKEN can publish to gh-pages

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68984af8f118832583d5122b7b12480b