### PR TITLE
feat: add reset control and improve GitHub Pages config

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,39 +293,38 @@ Run from repo root with `pnpm --filter ./apps/web <script>` (or `cd apps/web`).
 
 **Workflow**: build static site → publish `apps/web/out` to `gh-pages` branch.
 
-**`.github/workflows/gh-pages.yml`**
+**`.github/workflows/deploy.yml`**
 
 ```yaml
 name: Deploy to GitHub Pages
 on:
   push:
     branches: [ main ]
-  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
-  build-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
       - uses: actions/setup-node@v4
-        with: { node-version: 20 }
-      - run: corepack enable
-      - run: pnpm install --frozen-lockfile
-      - name: Build (static export)
-        env:
-          CI: true
-          NEXT_PUBLIC_REPO_NAME: orb-alchemy
-        run: |
-          pnpm --filter ./apps/web build
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm --filter web build
+      - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./apps/web/out
+          publish_dir: apps/web/out
 ```
+
+`next.config.mjs` derives the repository name from `GITHUB_REPOSITORY`, so the site works on GitHub Pages without extra configuration. Set `NEXT_PUBLIC_REPO_NAME` to override this behavior when needed.
 
 **GitHub settings → Pages**: Source = `gh-pages` branch, `/ (root)`.
 

--- a/apps/web/features/sim/SimCanvas.tsx
+++ b/apps/web/features/sim/SimCanvas.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useEffect } from 'react';
 import { useSimStore } from './store';
 import { Ball } from './engine/ball';
 import { CircleBoundary } from './engine/circleBoundary';
@@ -10,18 +10,25 @@ import { draw } from './renderers/canvasRenderer';
 
 export function SimCanvas() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const ballRef = useRef<Ball>({
+  const initialBall: Ball = {
     position: { x: 150, y: 150 },
     velocity: { x: 60, y: 40 },
     radius: 20,
-  });
+  };
+  const ballRef = useRef<Ball>({ ...initialBall });
 
   const boundary: CircleBoundary = {
     center: { x: 150, y: 150 },
     radius: 140,
   };
 
-  const { gravity, speed, trail, guides, paused } = useSimStore();
+  const { gravity, speed, trail, guides, paused, resetCount } = useSimStore();
+
+  useEffect(() => {
+    ballRef.current = { ...initialBall };
+    const ctx = canvasRef.current?.getContext('2d');
+    if (ctx) ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  }, [resetCount]);
 
   const tick = useCallback(
     (dt: number) => {
@@ -35,11 +42,14 @@ export function SimCanvas() {
         if (!trail) ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
         draw(ctx, ball);
         if (guides) {
+          ctx.save();
+          if (trail) ctx.globalCompositeOperation = 'destination-over';
           ctx.strokeStyle = 'rgba(255,255,255,0.2)';
           ctx.lineWidth = 2;
           ctx.beginPath();
           ctx.arc(boundary.center.x, boundary.center.y, boundary.radius, 0, Math.PI * 2);
           ctx.stroke();
+          ctx.restore();
         }
       }
     },

--- a/apps/web/features/sim/SimControls.tsx
+++ b/apps/web/features/sim/SimControls.tsx
@@ -18,6 +18,7 @@ export function SimControls() {
     toggleGuides,
     paused,
     togglePause,
+    reset,
   } = useSimStore();
 
   return (
@@ -67,13 +68,21 @@ export function SimControls() {
       <label className="flex items-center gap-2">
         <input type="checkbox" checked={guides} onChange={toggleGuides} /> Guides
       </label>
-      <button
-        onClick={togglePause}
-        className="mt-2 flex items-center gap-1 rounded bg-neutral-800 px-2 py-1"
-      >
-        {paused ? <Play size={16} /> : <Pause size={16} />}
-        {paused ? 'Resume' : 'Pause'}
-      </button>
+      <div className="mt-2 flex gap-2">
+        <button
+          onClick={togglePause}
+          className="flex items-center gap-1 rounded bg-neutral-800 px-2 py-1"
+        >
+          {paused ? <Play size={16} /> : <Pause size={16} />}
+          {paused ? 'Resume' : 'Pause'}
+        </button>
+        <button
+          onClick={reset}
+          className="flex items-center gap-1 rounded bg-neutral-800 px-2 py-1"
+        >
+          Reset
+        </button>
+      </div>
     </motion.div>
   );
 }

--- a/apps/web/features/sim/renderers/canvasRenderer.ts
+++ b/apps/web/features/sim/renderers/canvasRenderer.ts
@@ -2,7 +2,6 @@ import type { Ball } from '../engine/ball';
 
 export function draw(ctx: CanvasRenderingContext2D, ball: Ball) {
   const { position, radius } = ball;
-  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
   ctx.fillStyle = 'white';
   ctx.beginPath();
   ctx.arc(position.x, position.y, radius, 0, Math.PI * 2);

--- a/apps/web/features/sim/store.ts
+++ b/apps/web/features/sim/store.ts
@@ -9,12 +9,14 @@ interface SimState {
   trail: boolean;
   guides: boolean;
   paused: boolean;
+  resetCount: number;
   setMode: (mode: Mode) => void;
   setGravity: (gravity: number) => void;
   setSpeed: (speed: number) => void;
   toggleTrail: () => void;
   toggleGuides: () => void;
   togglePause: () => void;
+  reset: () => void;
 }
 
 export const useSimStore = create<SimState>((set) => ({
@@ -24,10 +26,12 @@ export const useSimStore = create<SimState>((set) => ({
   trail: false,
   guides: true,
   paused: false,
+  resetCount: 0,
   setMode: (mode) => set({ mode }),
   setGravity: (gravity) => set({ gravity }),
   setSpeed: (speed) => set({ speed }),
   toggleTrail: () => set((s) => ({ trail: !s.trail })),
   toggleGuides: () => set((s) => ({ guides: !s.guides })),
   togglePause: () => set((s) => ({ paused: !s.paused })),
+  reset: () => set((s) => ({ resetCount: s.resetCount + 1, paused: false })),
 }));

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,4 +1,7 @@
-const repo = process.env.NEXT_PUBLIC_REPO_NAME || '';
+const repo =
+  process.env.NEXT_PUBLIC_REPO_NAME ||
+  process.env.GITHUB_REPOSITORY?.split('/')[1] ||
+  '';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {


### PR DESCRIPTION
## Summary
- allow ball state reset from controls
- fix trail rendering by avoiding unnecessary canvas clears
- derive repo name for GitHub Pages automatically and document deployment

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6898e3570c888325a0653ec08d8a4766